### PR TITLE
RFC: Add a --names-only flag

### DIFF
--- a/src/.depend
+++ b/src/.depend
@@ -7,7 +7,7 @@ supermin.cmo: supermin_utils.cmi supermin_package_handlers.cmi supermin_cmdline.
 supermin.cmx: supermin_utils.cmx supermin_package_handlers.cmx supermin_cmdline.cmx config.cmx
 supermin_debian.cmo: supermin_utils.cmi supermin_package_handlers.cmi supermin_cmdline.cmi config.cmo
 supermin_debian.cmx: supermin_utils.cmx supermin_package_handlers.cmx supermin_cmdline.cmx config.cmx
-supermin_package_handlers.cmi:
+supermin_package_handlers.cmi: supermin_cmdline.cmi
 supermin_package_handlers.cmo: supermin_utils.cmi supermin_cmdline.cmi supermin_package_handlers.cmi
 supermin_package_handlers.cmx: supermin_utils.cmx supermin_cmdline.cmx supermin_package_handlers.cmi
 supermin_pacman.cmo: supermin_utils.cmi supermin_package_handlers.cmi supermin_cmdline.cmi config.cmo

--- a/src/supermin.ml
+++ b/src/supermin.ml
@@ -41,7 +41,7 @@ let () =
   debug "selected package handler: %s" (get_package_handler_name ());
 
   (* Not --names: check files exist. *)
-  if not names_mode then (
+  if mode == PkgFiles then (
     List.iter (
       fun pkg ->
         if not (file_exists pkg) then (
@@ -55,8 +55,8 @@ let () =
    * (including dependencies).
    *)
   let packages =
-    if names_mode then (
-      let packages = ph.ph_resolve_dependencies_and_download packages in
+    if mode != PkgFiles then (
+      let packages = ph.ph_resolve_dependencies_and_download packages mode in
       debug "resolved packages: %s" (String.concat " " packages);
       packages
     )

--- a/src/supermin_cmdline.ml
+++ b/src/supermin_cmdline.ml
@@ -18,8 +18,13 @@
 
 open Printf
 
+type mode =
+  |PkgFiles
+  |PkgNames
+  |PkgNamesOnly
+
 let excludes = ref []
-let names_mode = ref false
+let mode = ref PkgFiles
 let outputdir = ref "."
 let packages = ref []
 let save_temps = ref false
@@ -52,8 +57,10 @@ let set_packager_config filename =
 let argspec = Arg.align [
   "--exclude", Arg.String add_exclude,
     "regexp Exclude packages matching regexp";
-  "--names", Arg.Set names_mode,
+  "--names", Arg.Unit (fun () -> mode := PkgNames),
     " Specify set of root package names on command line";
+  "--names-only", Arg.Unit (fun () -> mode := PkgNamesOnly),
+    " Specify exact set of package names on command line";
   "--no-warnings", Arg.Clear warnings,
     " Suppress warnings";
   "-o", Arg.Set_string outputdir,
@@ -101,7 +108,7 @@ let () =
   )
 
 let excludes = List.rev !excludes
-let names_mode = !names_mode
+let mode = !mode
 let outputdir = !outputdir
 let packages = List.rev !packages
 let save_temps = !save_temps

--- a/src/supermin_cmdline.mli
+++ b/src/supermin_cmdline.mli
@@ -22,12 +22,16 @@ val debug : ('a, unit, string, unit) format4 -> 'a
   (** Print string (like printf), but only if --verbose was given on
       the command line. *)
 
+type mode =
+  |PkgFiles
+  |PkgNames
+  |PkgNamesOnly
+
 val excludes : Str.regexp list
   (** List of package regexps to exclude. *)
 
-val names_mode : bool
-  (** True if [--names] was given on the command line (otherwise
-      {!packages} is a list of filenames). *)
+val mode : mode
+  (** How to interpret {!packages} *)
 
 val outputdir : string
   (** Output directory. *)

--- a/src/supermin_debian.ml
+++ b/src/supermin_debian.ml
@@ -53,9 +53,12 @@ let get_installed_pkgs () =
 let which_dependencies = "-i"
 (*let which_dependencies = "--no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances"*)
 
-let rec debian_resolve_dependencies_and_download names =
+let rec debian_resolve_dependencies_and_download names mode =
+  let which_dependencies =
+    if mode == PkgNames then which_dependencies ^ " --recurse"
+    else which_dependencies in
   let cmd =
-    sprintf "%s depends --recurse %s %s | grep -v '^[<[:space:]]' | grep -Ev ':\\w+\\b'"
+    sprintf "%s depends %s %s | grep -v '^[<[:space:]]' | grep -Ev ':\\w+\\b'"
       Config.apt_cache which_dependencies
       (String.concat " " (List.map Filename.quote names)) in
   let pkgs = run_command_get_lines cmd in

--- a/src/supermin_package_handlers.ml
+++ b/src/supermin_package_handlers.ml
@@ -25,7 +25,7 @@ open Supermin_cmdline
 type package_handler = {
   ph_detect : unit -> bool;
   ph_init : unit -> unit;
-  ph_resolve_dependencies_and_download : string list -> string list;
+  ph_resolve_dependencies_and_download : string list -> mode -> string list;
   ph_list_files : string -> (string * file_type) list;
   ph_get_file_from_package : string -> string -> string
 }

--- a/src/supermin_package_handlers.mli
+++ b/src/supermin_package_handlers.mli
@@ -29,8 +29,8 @@ type package_handler = {
       This is only called on the package handler if it has returned
       [true] from {!ph_detect}. *)
 
-  ph_resolve_dependencies_and_download : string list -> string list;
-  (** [ph_resolve_dependencies_and_download pkgs]
+  ph_resolve_dependencies_and_download : string list -> Supermin_cmdline.mode -> string list;
+  (** [ph_resolve_dependencies_and_download pkgs mode]
       Take a list of package names, and using the package manager
       resolve those to a list of all the packages that are required
       including dependencies.  Download the full list of packages and

--- a/src/supermin_pacman.ml
+++ b/src/supermin_pacman.ml
@@ -36,7 +36,7 @@ let pacman_init () =
   if use_installed then
     failwith "pacman driver doesn't support --use-installed"
 
-let pacman_resolve_dependencies_and_download names =
+let pacman_resolve_dependencies_and_download names mode =
   let cmd =
     sprintf "(for p in %s; do pactree -u $p; done) | awk '{print $1}' | sort -u"
       (String.concat " " (List.map Filename.quote names)) in

--- a/src/supermin_yum_rpm.ml
+++ b/src/supermin_yum_rpm.ml
@@ -36,7 +36,7 @@ let yum_rpm_init () =
   if use_installed then
     failwith "yum_rpm driver doesn't support --use-installed"
 
-let yum_rpm_resolve_dependencies_and_download names =
+let yum_rpm_resolve_dependencies_and_download names mode =
   (* Liberate this data from python. *)
   let tmpfile = tmpdir // "names.tmp" in
   let py = sprintf "

--- a/src/supermin_zypp_rpm.ml
+++ b/src/supermin_zypp_rpm.ml
@@ -76,7 +76,7 @@ let zypp_rpm_init () =
   if use_installed then
     eprintf "supermin: zypp_rpm driver assumes all packages are already installed when called with option --use-installed.\n%!"
 
-let zypp_rpm_resolve_dependencies_and_download_no_installed names =
+let zypp_rpm_resolve_dependencies_and_download_no_installed names mode =
   (* Liberate this data from shell. *)
   let tmp_pkg_cache_dir = tmpdir // "pkg_cache_dir" in
   let tmp_root = tmpdir // "root" in
@@ -138,7 +138,7 @@ time zypper \
   (* Return list of package filenames. *)
   pkgs
 
-let zypp_rpm_resolve_dependencies_and_download_use_installed names =
+let zypp_rpm_resolve_dependencies_and_download_use_installed names mode =
   let cmd = sprintf "
 %s
 unset LANG ${!LC_*}
@@ -169,11 +169,11 @@ zypper \
   (* Return list of package names, remove empty lines. *)
   List.filter (fun s -> s <> "") pkg_names
 
-let zypp_rpm_resolve_dependencies_and_download names =
+let zypp_rpm_resolve_dependencies_and_download names mode =
   if use_installed then
-    zypp_rpm_resolve_dependencies_and_download_use_installed names
+    zypp_rpm_resolve_dependencies_and_download_use_installed names mode
   else
-    zypp_rpm_resolve_dependencies_and_download_no_installed names
+    zypp_rpm_resolve_dependencies_and_download_no_installed names mode
 
 let rec zypp_rpm_list_files pkg =
   (* Run rpm -qlp with some extra magic. *)


### PR DESCRIPTION
This takes a list of package names, adding them to the image
without pulling any dependencies.

Only implemented for Debian at the moment.
zypper wasn't build-tested because I don't have the dependency.
