### PR TITLE
Add stdarg.h to fix issues with va_start

### DIFF
--- a/helper/utils.c
+++ b/helper/utils.c
@@ -18,6 +18,7 @@
 
 #include <config.h>
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
Otherwise I got errors like these:

http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/sys-apps/shadow/files/shadow-4.1.5-stdarg.patch?view=diff&r1=text&tr1=1.1&r2=text&tr2=1.1&diff_format=s
