### PR TITLE
package handlers: Replace supermin with supermin5 in the error message

### DIFF
--- a/src/package_handler.ml
+++ b/src/package_handler.ml
@@ -127,7 +127,7 @@ then it may be that the package detection code is not working.
 To list which package handlers are compiled into this version of
 supermin, do:
 
-  supermin --list-drivers
+  supermin5 --list-drivers
 "
 
 let rec get_package_handler () =


### PR DESCRIPTION
Replace supermin with supermin5 in the error message, since supermin does
not support "--list-drivers" option as following:

cmd> supermin --list-drivers
supermin: unknown option '--list-drivers'.
supermin - tool for creating supermin appliances
...

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>