### PR TITLE
src/format_ext2_kernel.ml: Fix kernel filtering for aarch64 architecture

### DIFF
--- a/src/format_ext2_kernel.ml
+++ b/src/format_ext2_kernel.ml
@@ -187,6 +187,7 @@ and patt_of_cpu host_cpu =
     | "amd64" | "x86_64" -> ["amd64"; "x86_64"]
     | "parisc" | "parisc64" -> ["hppa"; "hppa64"]
     | "ppc64el" -> ["powerpc64le"]
+    | "aarch64" -> ["aarch64"; "arm64"]
     | _ when host_cpu.[0] = 'i' && host_cpu.[2] = '8' && host_cpu.[3] = '6' -> ["?86"]
     | _ when String.length host_cpu >= 5 && String.sub host_cpu 0 5 = "armv7" ->  ["armmp"]
     | _ -> [host_cpu]


### PR DESCRIPTION
Add appropriate globs for arm based kernels. The file names end in -arm64 but the architecture is named aarch64.