### PR TITLE
dpkg: prefer exact package names over providers

### DIFF
--- a/src/ph_dpkg.ml
+++ b/src/ph_dpkg.ml
@@ -70,6 +70,15 @@ let dpkg_package_of_string str =
     ) lines
   );
   let candidates = Hashtbl.find_all dpkg_packages str in
+  (* Prefer an exact package name over a virtual package provider.  For
+   * example, Debian has both the real "coreutils" package and packages
+   * which "Provides: coreutils"; when the appliance asks for coreutils it
+   * needs the real package's file list, not an arbitrary provider's.
+   *)
+  let candidates =
+    let exact, providers =
+      List.partition (fun cand -> cand.name = str) candidates in
+    exact @ providers in
   (* On multiarch setups, only consider the primary architecture *)
   try
     let pkg = List.find (


### PR DESCRIPTION
When a dpkg package name is both a real package and a virtual package provided by another installed package, the dpkg resolver can currently pick the provider first.

On my Debian testing/sid host I have:

```text
coreutils 9.10-1 amd64 install ok installed;
coreutils-from-uutils 0.0.0 all install ok installed; coreutils, coreutils-from
rust-coreutils 0.8.0-1 amd64 install ok installed;
```

With the installed supermin, a minimal appliance built from `coreutils` selects the virtual provider and gets `/usr/bin/coreutils` but not the expected GNU coreutils applets:

```sh
supermin --prepare coreutils -o /tmp/supermin-coreutils-repro/supermin.d
supermin --build -f chroot /tmp/supermin-coreutils-repro/supermin.d -o /tmp/supermin-coreutils-repro/out
test -e /tmp/supermin-coreutils-repro/out/usr/bin/ls; echo ls=$?
test -e /tmp/supermin-coreutils-repro/out/usr/bin/coreutils; echo coreutils=$?
```

Before this patch:

```text
ls=1
coreutils=0
coreutils
```

This broke libguestfs appliance boot for me because `/init` and `guestfsd` expected commands such as `mkdir`, `ls`, and `cat`.

The fix keeps the existing architecture filtering, but searches exact package-name matches before virtual providers. Providers still remain as fallback candidates when there is no exact installed package.

After this patch, the same source-tree repro gives:

```text
ls=0
coreutils=1
cat
ls
mkdir
```

Validation run:

```text
make -C tests check TESTS=test-binaries-exist.sh
# TOTAL: 1
# PASS:  1
```

Note: I saw `HACKING` says to send patches to the libguestfs mailing list as well; I am happy to send this there too if that is preferred.
